### PR TITLE
assets-32: break long titles so the edit button is not hidden

### DIFF
--- a/apps/client-asset-sg/src/styles.scss
+++ b/apps/client-asset-sg/src/styles.scss
@@ -877,3 +877,7 @@ input {
 .ellipsis {
     @include mixins.text-ellipsis;
 }
+
+.break-word {
+  word-break: break-all;
+}

--- a/libs/asset-viewer/src/lib/components/asset-search-detail/asset-search-detail.component.html
+++ b/libs/asset-viewer/src/lib/components/asset-search-detail/asset-search-detail.component.html
@@ -16,7 +16,7 @@
         <ng-container *rxLet="rdAssetDetail$ | push; let rdAssetDetail">
             <ng-container *ngIf="rdAssetDetail._tag === 'RemoteSuccess'">
                 <div class="flex flex-row justify-between mb-4">
-                    <div class="text-dark-red font-bold mt-2.5" [innerHTML]="rdAssetDetail.value.titlePublic"></div>
+                    <div class="text-dark-red break-word font-bold mt-2.5" [innerHTML]="rdAssetDetail.value.titlePublic"></div>
                     <a
                         *ngIf="null | isEditor"
                         asset-sg-icon-button

--- a/libs/asset-viewer/src/lib/components/asset-search-results/asset-search-results.component.html
+++ b/libs/asset-viewer/src/lib/components/asset-search-results/asset-search-results.component.html
@@ -50,7 +50,7 @@
                             [routerLink]="['.']"
                             [queryParams]="{ assetId: asset.assetId }"
                             queryParamsHandling="merge"
-                            class="asset-title-public"
+                            class="asset-title-public break-word"
                             [class.active]="currentAssetId._tag === 'Some' && asset.assetId === currentAssetId.value"
                             [innerHTML]="asset.titlePublic"></a>
                         <div class="asset-kind-format">


### PR DESCRIPTION
To test this, search for "laaaaaaaaaaaaaannnnnnngggggggggeeeerrrrrrTiteeeeeeeeeLLLLLLLLL" in the searchbar, and select the element (created with admin@assts.sg user).
The title is now on multiple lines and the edit button still visibile