### PR TITLE
assets-39: remove console log of password from test

### DIFF
--- a/apps/client-asset-sg-e2e/src/support/commands.ts
+++ b/apps/client-asset-sg-e2e/src/support/commands.ts
@@ -18,7 +18,7 @@ declare namespace Cypress {
 //
 // -- This is a parent command --
 Cypress.Commands.add('login', (email, password) => {
-    console.log('Custom command example: Login', email, password);
+    console.log('Custom command example: Login');
 });
 //
 // -- This is a child command --


### PR DESCRIPTION
I just removed the password from the console log to get rid of the security warning. 
We could also remove those files altogether, but maybe that is paart of a bigger cleanup.
@ga-ebp what are your thoughts on this?