### PR TITLE
Feature 34: Bug: Verdoppelung von Verweisen

### DIFF
--- a/apps/server-asset-sg/src/app/asset-edit/asset-edit.service.ts
+++ b/apps/server-asset-sg/src/app/asset-edit/asset-edit.service.ts
@@ -196,32 +196,10 @@ export class AssetEditService {
         return pipe(
             TE.tryCatch(
                 () =>
-                    this.prismaService.assetXAssetY.findMany({
+                    this.prismaService.assetXAssetY.deleteMany({
                         where: { OR: [{ assetXId: assetId }, { assetYId: assetId }] },
                     }),
                 unknownToUnknownError,
-            ),
-            TE.map(dbSiblingAssets =>
-                dbSiblingAssets.filter(
-                    a =>
-                        !patchAsset.siblingAssetIds.includes(a.assetXId) &&
-                        !patchAsset.siblingAssetIds.includes(a.assetYId),
-                ),
-            ),
-            TE.chain(dbSiblingAssetsToDelete =>
-                pipe(
-                    dbSiblingAssetsToDelete,
-                    A.map(({ assetXId, assetYId }) =>
-                        TE.tryCatch(
-                            () =>
-                                this.prismaService.assetXAssetY.delete({
-                                    where: { assetXId_assetYId: { assetXId, assetYId } },
-                                }),
-                            unknownToUnknownError,
-                        ),
-                    ),
-                    A.sequence(TE.ApplicativeSeq),
-                ),
             ),
             TE.chain(() =>
                 TE.tryCatch(
@@ -430,15 +408,15 @@ export class AssetEditService {
                 const d = new Date();
                 return file
                     ? fileNameWithoutTs +
-                          '_' +
-                          d.getFullYear() +
-                          (d.getMonth() + 1).toString().padStart(2, '0') +
-                          d.getDate().toString().padStart(2, '0') +
-                          d.getHours().toString().padStart(2, '0') +
-                          d.getMinutes().toString().padStart(2, '0') +
-                          d.getSeconds().toString().padStart(2, '0') +
-                          '.' +
-                          fileExtension
+                    '_' +
+                    d.getFullYear() +
+                    (d.getMonth() + 1).toString().padStart(2, '0') +
+                    d.getDate().toString().padStart(2, '0') +
+                    d.getHours().toString().padStart(2, '0') +
+                    d.getMinutes().toString().padStart(2, '0') +
+                    d.getSeconds().toString().padStart(2, '0') +
+                    '.' +
+                    fileExtension
                     : fileName;
             }),
             TE.bindTo('_fileName'),


### PR DESCRIPTION
Fix for #34.

Cause: Sibling assets are saved in the database via the `asset_x_asset_y` table. The table has two ids as its fields, one for each sibling. This means that it is possible for a sibling relationship two appear twice, by switching the values of the two id fields. In theory, the API guards against that by deleting duplicates before inserting new entities, but that check was faulty.

Fix: We now just delete all entities of `asset_x_asset_y` table that belong to the asset that is being modified, and then immediately insert all correct ones. This ensures that we remove any possible duplicates before even creating them.

Note that this does **not** remove any existing entities, see my comment in #34.